### PR TITLE
Reversed Org List Sort Order

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -65,7 +65,7 @@ block content
 
       - var currentPriority = ''
       - var oom = overview && overview.organizations ? overview.organizations.in : []
-      each o in oom
+      each o in Array.prototype.reverse(oom)
           div.link-box
             a(href=o.name + onboardingPostfixUrl)
               h2: strong= o.name


### PR DESCRIPTION
This should make the index page easier to navigate for those with a large number of GitHub Org memberships, it'll display based on Org join order instead of reverse Org join order (🤮).