### PR TITLE
Updates showOrgJoinDetails middleware to improve unlinked admin handling.

### DIFF
--- a/routes/org/join.ts
+++ b/routes/org/join.ts
@@ -66,15 +66,15 @@ async function showOrgJoinDetails(req: ReposAppRequest) {
     
     // linked and unlinked admins return slightly different data structures
     const login = member ? member.login : admin.login;
-
+    const avatar_url = member ? member.avatar_url : admin.avatar_url;
     // fallback to corporateUsername if corporateMailAddress is not available
     const mailAddress = link ? link.corporateMailAddress || link.corporateUsername : undefined;
-    const primaryName = link ? link.corporateDisplayName || link.corporateUsername : member.login;
+    const primaryName = link ? link.corporateDisplayName || link.corporateUsername : login;
     
     acc.push({
       login,
       mailAddress,
-      avatar_url: member.avatar_url,
+      avatar_url,
       primaryName
     })
 


### PR DESCRIPTION
I encountered this issue when setting up the app from a new, empty environment.  These minor fixes safely access object properties, preventing errors when an org admin is unlinked. 

This could theoretically also be causing GH-167, but I can't be positive until I get a chance to review the logs.