### PR TITLE
Copy Content review

### DIFF
--- a/views/removeothergithubaccount.pug
+++ b/views/removeothergithubaccount.pug
@@ -1,7 +1,7 @@
 //-
 //- Copyright (c) Microsoft.
 //- Licensed under the MIT license. See LICENSE file in the project root for full license information.
-//-
+//- EXAMPLE: is it worth being more NIH specific here
 
 extends layout
 


### PR DESCRIPTION
Starting a conversation around removing MS specific wording and branding from the UI.  Here is a list of files in the main `view` folder of the application that contain wording specific or related to the upstream MS portal implementation. 

  - linksUpdate.pug 
  - head.pug
  - linkConfirmed.pug
  - linkUpdate.pug
  - multipleaccounts.pug
  - removeothergithubaccount.pug
  - undo.pug
  - unlink.pug

In some cases we still need to be specific about the changes a user can affect themselves. For instances a user can leave an Org as the portal doesn't use the Github App to do that, instead using the user account. 
