### PR TITLE
Add pingInterval to the Redis configuration.

### DIFF
--- a/middleware/initialize.ts
+++ b/middleware/initialize.ts
@@ -590,6 +590,7 @@ async function connectRedis(
       port: config.redis.port ? Number(config.redis.port) : config.redis.tls ? 6380 : 6379,
       password: config.redis.key,
       tls: !!config.redis.tls,
+      pingInterval: 5 * 60 * 1000, // Ping Each 5min. https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout
     },
     // name
   };


### PR DESCRIPTION
This PR adds a configuration setting to ping Redis every 5 minutes.  See https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout for more information.