### PR TITLE
Move the pingInterval setting in to the root connection params.

### DIFF
--- a/middleware/initialize.ts
+++ b/middleware/initialize.ts
@@ -590,9 +590,8 @@ async function connectRedis(
       port: config.redis.port ? Number(config.redis.port) : config.redis.tls ? 6380 : 6379,
       password: config.redis.key,
       tls: !!config.redis.tls,
-      pingInterval: 5 * 60 * 1000, // Ping Each 5min. https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout
     },
-    // name
+    pingInterval: 5 * 60 * 1000, // Ping Each 5min. https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout
   };
   debug(`connecting to ${purpose} Redis ${redisConfig.host || redisConfig.tls}`);
   const redisClient: RedisClientType = createClient(redisOptions);


### PR DESCRIPTION
Setting the pingInterval in the socket configuration did not send the pings we were expecting.  After reviewing the [node-redis](https://github.com/redis/node-redis/blob/c64ce74383018266015e1fff6394261dad243dd1/packages/client/lib/client/index.ts#L68) library it appears this should be in the root configuration.