### PR TITLE
fix: Redis v5 client compatibility (hotfix for staging break)

### DIFF
--- a/middleware/initialize.ts
+++ b/middleware/initialize.ts
@@ -682,15 +682,14 @@ async function connectRedis(
     socket: {
       host: config.redis.tls || config.redis.host,
       port: config.redis.port ? Number(config.redis.port) : config.redis.tls ? 6380 : 6379,
-      password: config.redis.key,
       tls: !!config.redis.tls,
     },
+    password: config.redis.key,
     pingInterval: 5 * 60 * 1000, // Ping Each 5min. https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout
   };
   debug(`connecting to ${purpose} Redis ${redisConfig.host || redisConfig.tls}`);
   const redisClient: RedisClientType = createClient(redisOptions);
   await redisClient.connect();
-  await redisClient.auth({ password: config.redis.key });
 
   return redisClient;
 }

--- a/middleware/session.ts
+++ b/middleware/session.ts
@@ -50,11 +50,7 @@ export default async function ConnectSession(
     }
     const redisPrefix = config.session.redis.prefix ? `${config.session.redis.prefix}.session` : 'session';
     const redisLegacy = sessionRedisClient.duplicate();
-    redisLegacy.connect();
-
-    // NIH: Replaced with direct auth call as upstream's callback-based auth does not work
-    // in the NIH environment. See session.ts conflict notes.
-    await redisLegacy.auth({ password: config.session.redis.key });
+    await redisLegacy.connect();
     const redisOptions = {
       client: redisLegacy,
       ttl: config.session.redis.ttl,


### PR DESCRIPTION
Hotfix for the application error introduced after merging #1099.

## Root cause

The upstream `redis` v4 → v5 upgrade removed the `.auth()` method. NIH had a workaround using `.auth()` after `.connect()` (to handle Azure Cache for Redis auth), but this pattern no longer exists in v5. Additionally, the `password` option was inside the `socket` object where v5 expects it at the top level of `createClient()`.

## Changes

**`middleware/initialize.ts`**
- Moved `password` from inside `socket: {}` to top-level `createClient()` option
- Removed `await redisClient.auth(...)` — auth now happens automatically during `connect()`

**`middleware/session.ts`**
- Removed `await redisLegacy.auth(...)` for the same reason
- Fixed `redisLegacy.connect()` to be properly awaited (was fire-and-forget)