### PR TITLE
fix: update CI/CD workflows to Node 24 + bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install Dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,24 +18,27 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          cache: npm
+          node-version: '24.x'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install Dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Run Markdownlint
-        run: npm run lint:md
+        run: bun run lint:md
 
       - name: Run ESLint
-        run: npm run lint:js
+        run: bun run lint:js
 
       - name: Run cSpell
         run: |
           echo "::add-matcher::.github/workflows/cspell-problem-matcher.json"
-          npm run lint:spell
+          bun run lint:spell
 
       - name: Run tests
-        run: npm test
+        run: bun test
 
       - name: Build container
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,11 +15,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         # Override language selection by uncommenting this and choosing your languages
         # with:
         #   languages: go, javascript, csharp, python, cpp, java
@@ -27,7 +27,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -41,4 +41,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛒
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Packages 📦
         run: |
@@ -36,12 +36,12 @@ jobs:
     environment:
       name: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       #- uses: docker/build-push-action@v3
 
       - name: Azure OpenID Connect ✨
         if: github.repository == 'microsoft/opensource-management-portal' # official repo only
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
@@ -89,7 +89,7 @@ jobs:
       url: https://portal-staging.ospo.dev
     steps:
       - name: Azure OpenID Connect ✨
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}
@@ -113,7 +113,7 @@ jobs:
       url: https://portal.ospo.dev
     steps:
       - name: Azure OpenID Connect ✨
-        uses: azure/login@v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}

--- a/.github/workflows/main_create_acr_image.yaml
+++ b/.github/workflows/main_create_acr_image.yaml
@@ -8,43 +8,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: get orgs from graphql
-      run: |
-        gh api graphql -f ent=nih -f query='query($ent: String!) {
-          enterprise(slug: $ent) {
-            organizations(first: 100) {
-              nodes {
-                description
-                login
-                databaseId
-                id
-                name
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: get orgs from graphql
+        run: |
+          gh api graphql -f ent=nih -f query='query($ent: String!) {
+            enterprise(slug: $ent) {
+              organizations(first: 100) {
+                nodes {
+                  description
+                  login
+                  databaseId
+                  id
+                  name
+                }
               }
             }
-          }
-        }' >> raw.json
-        cat raw.json
-      env:
-        GITHUB_TOKEN: ${{ secrets.ENT_READ_PAT}}
-    - name: run powershell script to create env orgs json
-      run: |
-        ./.github/scripts/Create-EnvOrgs.ps1
-        cat orgs.json
-        ls
-      shell: pwsh
-    - name: check file
-      run: |
-        cat orgs.json
-        ls -lah
-        rm env-orgs.json
-        cat orgs.json >> env-orgs.json
-        cat env-orgs.json
-    - uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.PROD_REGISTRY_SERVER }}
-        username: ${{ secrets.PROD_REGISTRY_USER }}
-        password: ${{ secrets.PROD_REGISTRY_PASS }}
-    - run: |
-        docker build . -t ${{ secrets.PROD_REGISTRY_SERVER }}/portal
-        docker push ${{ secrets.PROD_REGISTRY_SERVER }}/portal
+          }' >> raw.json
+          cat raw.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.ENT_READ_PAT}}
+      - name: run powershell script to create env orgs json
+        run: |
+          ./.github/scripts/Create-EnvOrgs.ps1
+          cat orgs.json
+          ls
+        shell: pwsh
+      - name: check file
+        run: |
+          cat orgs.json
+          ls -lah
+          rm env-orgs.json
+          cat orgs.json >> env-orgs.json
+          cat env-orgs.json
+      - uses: azure/docker-login@15c4aadf093404726ab2ff205b2cdd33fa6d054c # v2
+        with:
+          login-server: ${{ secrets.PROD_REGISTRY_SERVER }}
+          username: ${{ secrets.PROD_REGISTRY_USER }}
+          password: ${{ secrets.PROD_REGISTRY_PASS }}
+      - run: |
+          docker build . -t ${{ secrets.PROD_REGISTRY_SERVER }}/portal
+          docker push ${{ secrets.PROD_REGISTRY_SERVER }}/portal

--- a/.github/workflows/main_nihgithubportal.yml
+++ b/.github/workflows/main_nihgithubportal.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -46,7 +46,7 @@ jobs:
           ls -lah
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: node-app
           path: /home/runner/work/github-portal/output.tar.gz
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: node-app
 
@@ -71,7 +71,7 @@ jobs:
 
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: 'nihgithubportal'
           slot-name: 'Production'

--- a/.github/workflows/main_nihgithubportal.yml
+++ b/.github/workflows/main_nihgithubportal.yml
@@ -14,35 +14,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
-          
-      - name: npm install, build, and test
-        run: |
-          npm install
-          npm run build --if-present
-          cd ./default-assets-package
-          npm install
-          npm run build
-          cd ..
-          npm run test --if-present
-                  
+          node-version: '24.x'
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        run: bun run build
+
+      - name: Build default-assets-package
+        run: cd ./default-assets-package && bun install --frozen-lockfile --ignore-scripts && bun run build
+
+      - name: Test
+        run: bun run test --if-present
+
+      - name: Prune dev dependencies
+        run: rm -rf node_modules && bun install --frozen-lockfile --ignore-scripts --production
+
       - name: zip application folders
         run: |
-          echo $PWD
-          ls -lah
           cd ..
-          echo $PWD
-          ls -lah
           tar -czf output.tar.gz ./github-portal
           ls -lah
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: node-app
           path: /home/runner/work/github-portal/output.tar.gz
@@ -56,10 +60,10 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: node-app
-    
+
       - name: Unpack tar
         run: |
           tar -xf output.tar.gz
@@ -67,7 +71,7 @@ jobs:
 
       - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v2
+        uses: azure/webapps-deploy@v3
         with:
           app-name: 'nihgithubportal'
           slot-name: 'Production'

--- a/.github/workflows/main_update_orgsettings_table.yaml
+++ b/.github/workflows/main_update_orgsettings_table.yaml
@@ -6,65 +6,62 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
-     - uses: actions/checkout@v2
-     - uses: ruby/setup-ruby@v1.127.0
-       with:
-        ruby-version: '3.0' # Not needed with a .ruby-version file
-     
-     - name: update ruby reqs
-       run: |
-        gem install jwt
-     # ruby jwt script has hardcoded reference to GitHub app id - unique in each branch   
-     - name: run jwt generator
-       run: |
-         ruby .github/scripts/jwt.rb >> token 
-         ls -lah       
-       env:
-         PEM: ${{ secrets.PROD_APP_PEM }}
-         APPID: ${{ secrets.PROD_APP_ID }}
-          
-        
-     - name: run gh cli to get app install info
-       run: |
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+        with:
+          ruby-version: '3.0' # Not needed with a .ruby-version file
+
+      - name: update ruby reqs
+        run: |
+          gem install jwt
+      # ruby jwt script has hardcoded reference to GitHub app id - unique in each branch
+      - name: run jwt generator
+        run: |
+          ruby .github/scripts/jwt.rb >> token 
+          ls -lah
+        env:
+          PEM: ${{ secrets.PROD_APP_PEM }}
+          APPID: ${{ secrets.PROD_APP_ID }}
+
+      - name: run gh cli to get app install info
+        run: |
           curl \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer $(cat token)" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/app/installations?per_page=100 | jq >> app_output.json
           cat ./app_output.json
-      
-     # needs a PAT that can read org and enterprise data 
-     - name: run powershell script to build sql
-       run: | 
+
+      # needs a PAT that can read org and enterprise data
+      - name: run powershell script to build sql
+        run: |
           .github/scripts/Create-PSQLUpdate.ps1
-       shell: pwsh
-          
-       env:
-        PAT: ${{ secrets.ENT_READ_PAT }}
-        
-     - name: output sql
-       run: |
-        ls -lah
-        cat ./app_output.json
-        cat ./update.sql
-        
-     - name: Azure Login 
-       uses: Azure/login@v1.4.6
-       with:
-         creds: '{"clientId":"${{ secrets.AAD_CLIENT_ID }}","clientSecret":"${{ secrets.AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AAD_TENANT_ID }}"}'
-         
-     - name: PSQL update
-       uses: azure/postgresql@v1
-       with:
-        connection-string: ${{ secrets.PROD_PSQL_CONN }}
-        server-name: $${{ secrets.PROD_PSQL_SERVER }}
-        plsql-file: ./update.sql
-        
-     - name: Azure CLI Action
-       uses: Azure/cli@v1
-       with:
-        # Needs the azure webapp name and resource group - unique in each branch
-        inlineScript: az webapp restart --name ${{ secrets.PROD_AAS }} --resource-group ${{ secrets.PROD_RG }}  
-        
+        shell: pwsh
+        env:
+          PAT: ${{ secrets.ENT_READ_PAT }}
+
+      - name: output sql
+        run: |
+          ls -lah
+          cat ./app_output.json
+          cat ./update.sql
+
+      - name: Azure Login
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          creds: '{"clientId":"${{ secrets.AAD_CLIENT_ID }}","clientSecret":"${{ secrets.AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AAD_TENANT_ID }}"}'
+
+      - name: PSQL update
+        uses: azure/postgresql@59401b7890419c83f372819a1c37f5aecf57ac92 # v1
+        with:
+          connection-string: ${{ secrets.PROD_PSQL_CONN }}
+          server-name: $${{ secrets.PROD_PSQL_SERVER }}
+          plsql-file: ./update.sql
+
+      - name: Azure CLI Action
+        uses: Azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        with:
+          # Needs the azure webapp name and resource group - unique in each branch
+          inlineScript: az webapp restart --name ${{ secrets.PROD_AAS }} --resource-group ${{ secrets.PROD_RG }}

--- a/.github/workflows/staging_create_acr_image.yml
+++ b/.github/workflows/staging_create_acr_image.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.DEV_REGISTRY_SERVER }}
-        username: ${{ secrets.DEV_REGISTRY_USER }}
-        password: ${{ secrets.DEV_REGISTRY_PASS }}
-    - run: |
-        docker build . -t ${{ secrets.DEV_REGISTRY_SERVER }}/portal
-        docker push ${{ secrets.DEV_REGISTRY_SERVER }}/portal
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: azure/docker-login@15c4aadf093404726ab2ff205b2cdd33fa6d054c # v2
+        with:
+          login-server: ${{ secrets.DEV_REGISTRY_SERVER }}
+          username: ${{ secrets.DEV_REGISTRY_USER }}
+          password: ${{ secrets.DEV_REGISTRY_PASS }}
+      - run: |
+          docker build . -t ${{ secrets.DEV_REGISTRY_SERVER }}/portal
+          docker push ${{ secrets.DEV_REGISTRY_SERVER }}/portal

--- a/.github/workflows/staging_nihdevgithubportal.yml
+++ b/.github/workflows/staging_nihdevgithubportal.yml
@@ -19,25 +19,29 @@ jobs:
       - name: Set up Node.js version
         uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "24.x"
 
-      - name: npm install, build, and test
-        run: |
-          npm install
-          npm run build --if-present
-          cd ./default-assets-package
-          npm install
-          npm run build
-          cd ..
-          npm run test --if-present
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Build
+        run: bun run build
+
+      - name: Build default-assets-package
+        run: cd ./default-assets-package && bun install --frozen-lockfile --ignore-scripts && bun run build
+
+      - name: Test
+        run: bun run test --if-present
+
+      - name: Prune dev dependencies
+        run: rm -rf node_modules && bun install --frozen-lockfile --ignore-scripts --production
 
       - name: zip application folders
         run: |
-          echo $PWD
-          ls -lah
           cd ..
-          echo $PWD
-          ls -lah
           tar -czf output.tar.gz ./github-portal
           ls -lah
 

--- a/.github/workflows/staging_nihdevgithubportal.yml
+++ b/.github/workflows/staging_nihdevgithubportal.yml
@@ -14,15 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Node.js version
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.x"
+          node-version: '24.x'
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile --ignore-scripts
@@ -46,7 +46,7 @@ jobs:
           ls -lah
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: node-app
           path: /home/runner/work/github-portal/output.tar.gz
@@ -55,12 +55,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment:
-      name: "Production"
+      name: 'Production'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: node-app
 
@@ -69,11 +69,11 @@ jobs:
           tar -xf output.tar.gz
           ls -lah
 
-      - name: "Deploy to Azure Web App"
+      - name: 'Deploy to Azure Web App'
         id: deploy-to-webapp
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
-          app-name: "nihdevgithubportal"
-          slot-name: "Production"
+          app-name: 'nihdevgithubportal'
+          slot-name: 'Production'
           publish-profile: ${{ secrets.AZUREAPPSERVICE_PUBLISHPROFILE_34824FEBDA0F4C8CACF5CB97111CBFFB }}
           package: .

--- a/.github/workflows/staging_update_orgsettings_table.yaml
+++ b/.github/workflows/staging_update_orgsettings_table.yaml
@@ -6,69 +6,68 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    
-    steps:
-     - uses: actions/checkout@v2
-     - uses: ruby/setup-ruby@v1.127.0
-       with:
-        ruby-version: '3.0' # Not needed with a .ruby-version file
-     
-     - name: update ruby reqs
-       run: |
-        gem install jwt
-     # ruby jwt script has hardcoded reference to GitHub app id - unique in each branch   
-     - name: run jwt generator
-       run: |
-         ruby .github/scripts/jwt.rb >> token 
-         ls -lah       
-       env:
-         PEM: ${{ secrets.DEV_APP_PEM }}
-         APPID: ${{ secrets.DEV_APP_ID }}
-          
-    # JC Note: This version of this step is not working changing to use curl like for production
-    #  - name: run gh cli to get app install info
-    #    run: |
-    #      gh api --paginate \
-    #       -H "Accept: application/vnd.github+json" \
-    #       -H "Authorization: Bearer $(cat token)" \
-    #       -H "X-GitHub-Api-Version: 2022-11-28" \
-    #       app/installations | jq >> app_output.json
-     - name: run gh cli to get app install info
-       run: |
-        curl \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $(cat token)" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        https://api.github.com/app/installations?per_page=100 | jq >> app_output.json
-        cat ./app_output.json
 
-     # needs a PAT that can read org and enterprise data 
-     - name: run powershell script to build sql
-       run: | 
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ruby/setup-ruby@ee2113536afb7f793eed4ce60e8d3b26db912da4 # v1.127.0
+        with:
+          ruby-version: '3.0' # Not needed with a .ruby-version file
+
+      - name: update ruby reqs
+        run: |
+          gem install jwt
+      # ruby jwt script has hardcoded reference to GitHub app id - unique in each branch
+      - name: run jwt generator
+        run: |
+          ruby .github/scripts/jwt.rb >> token 
+          ls -lah
+        env:
+          PEM: ${{ secrets.DEV_APP_PEM }}
+          APPID: ${{ secrets.DEV_APP_ID }}
+
+      # JC Note: This version of this step is not working changing to use curl like for production
+      #  - name: run gh cli to get app install info
+      #    run: |
+      #      gh api --paginate \
+      #       -H "Accept: application/vnd.github+json" \
+      #       -H "Authorization: Bearer $(cat token)" \
+      #       -H "X-GitHub-Api-Version: 2022-11-28" \
+      #       app/installations | jq >> app_output.json
+      - name: run gh cli to get app install info
+        run: |
+          curl \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer $(cat token)" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/app/installations?per_page=100 | jq >> app_output.json
+          cat ./app_output.json
+
+      # needs a PAT that can read org and enterprise data
+      - name: run powershell script to build sql
+        run: |
           .github/scripts/Create-PSQLUpdate.ps1
-       shell: pwsh
-        
-     - name: output sql
-       run: |
-        ls -lah
-        cat ./app_output.json
-        cat ./update.sql
-        
-     - name: Azure Login 
-       uses: Azure/login@v1.4.6
-       with:
-         creds: '{"clientId":"${{ secrets.AAD_CLIENT_ID }}","clientSecret":"${{ secrets.AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AAD_TENANT_ID }}"}'
-         
-     - name: PSQL update
-       uses: azure/postgresql@v1
-       with:
-        connection-string: ${{ secrets.DEV_PSQL_CONN }}
-        server-name: $${{ secrets.DEV_PSQL_SERVER }}
-        plsql-file: ./update.sql
-        
-     - name: Azure CLI Action
-       uses: Azure/cli@v1
-       with:
-        # Needs the azure webapp name and resource group - unique in each branch
-        inlineScript: az webapp restart --name ${{ secrets.DEV_AAS }} --resource-group ${{ secrets.DEV_RG }}  
-        
+        shell: pwsh
+
+      - name: output sql
+        run: |
+          ls -lah
+          cat ./app_output.json
+          cat ./update.sql
+
+      - name: Azure Login
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          creds: '{"clientId":"${{ secrets.AAD_CLIENT_ID }}","clientSecret":"${{ secrets.AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AAD_TENANT_ID }}"}'
+
+      - name: PSQL update
+        uses: azure/postgresql@59401b7890419c83f372819a1c37f5aecf57ac92 # v1
+        with:
+          connection-string: ${{ secrets.DEV_PSQL_CONN }}
+          server-name: $${{ secrets.DEV_PSQL_SERVER }}
+          plsql-file: ./update.sql
+
+      - name: Azure CLI Action
+        uses: Azure/cli@9eb25b8360668fb0ecbafa808d40e2197b2f5f52 # v3.0.0
+        with:
+          # Needs the azure webapp name and resource group - unique in each branch
+          inlineScript: az webapp restart --name ${{ secrets.DEV_AAS }} --resource-group ${{ secrets.DEV_RG }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           stale-issue-message: This issue has been identified as stale because it
             has gone 30 days with no activity.


### PR DESCRIPTION
## Problem
Staging deployment was broken due to stale `node_modules`:
- Build ran on **Node 20** but App Service runs **Node 24** — different module resolution
- `npm install` was used with no `package-lock.json` (deleted in bun migration), so npm did an unconstrained fresh resolution, ignoring `bun.lock` and potentially installing wrong transitive versions
- This caused the `@azure/core-tracing` / `createTracingClient` export error at startup

## Changes
**`.github/workflows/staging_nihdevgithubportal.yml`**
- Node 20 → 24 (matches App Service runtime)
- `npm install` → `bun install --frozen-lockfile --ignore-scripts` (respects bun.lock, exact versions)
- Prune devDependencies before packaging (smaller artifact, no build tools in prod)
- Split into explicit build / test / prune steps

**`.github/workflows/ci.yml`**
- Add `oven-sh/setup-bun@v2`; remove npm cache
- All `npm` → `bun` equivalents
- Node version set to 24.x

**`.github/workflows/main_nihgithubportal.yml`**
- Node 16 → 24
- Same npm → bun migration as staging workflow
- Bump `actions/checkout`, `setup-node`, `upload/download-artifact` to v4; `webapps-deploy` to v3