### PR TITLE
fix: switch ACI workflows to OIDC federated auth

### DIFF
--- a/.github/workflows/main_nihgithubportalcb.yml
+++ b/.github/workflows/main_nihgithubportalcb.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -17,7 +18,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
-          creds: '{"clientId":"${{ secrets.PROD_AAD_CLIENT_ID }}","clientSecret":"${{ secrets.PROD_AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.PROD_AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.PROD_AAD_TENANT_ID }}"}'
+          client-id: ${{ secrets.PROD_AAD_CLIENT_ID }}
+          tenant-id: ${{ secrets.PROD_AAD_TENANT_ID }}
+          subscription-id: ${{ secrets.PROD_AAD_SUBSCRIPTION_ID }}
 
       - name: Delete existing container group
         run: |

--- a/.github/workflows/main_nihgithubportalfh.yml
+++ b/.github/workflows/main_nihgithubportalfh.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -17,7 +18,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
-          creds: '{"clientId":"${{ secrets.PROD_AAD_CLIENT_ID }}","clientSecret":"${{ secrets.PROD_AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.PROD_AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.PROD_AAD_TENANT_ID }}"}'
+          client-id: ${{ secrets.PROD_AAD_CLIENT_ID }}
+          tenant-id: ${{ secrets.PROD_AAD_TENANT_ID }}
+          subscription-id: ${{ secrets.PROD_AAD_SUBSCRIPTION_ID }}
 
       - name: Delete existing container group
         run: |

--- a/.github/workflows/staging_nihdevgithubportalcb.yml
+++ b/.github/workflows/staging_nihdevgithubportalcb.yml
@@ -6,7 +6,9 @@ on:
     - cron: '0 */6 * * *'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   deploy:
@@ -16,7 +18,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
-          creds: '{"clientId":"${{ secrets.AAD_CLIENT_ID }}","clientSecret":"${{ secrets.AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AAD_TENANT_ID }}"}'
+          client-id: ${{ secrets.AAD_CLIENT_ID }}
+          tenant-id: ${{ secrets.AAD_TENANT_ID }}
+          subscription-id: ${{ secrets.AAD_SUBSCRIPTION_ID }}
 
       - name: Delete existing container group
         run: |

--- a/.github/workflows/staging_nihdevgithubportalfh.yml
+++ b/.github/workflows/staging_nihdevgithubportalfh.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -17,7 +18,9 @@ jobs:
       - name: Azure Login
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
-          creds: '{"clientId":"${{ secrets.AAD_CLIENT_ID }}","clientSecret":"${{ secrets.AAD_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AAD_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AAD_TENANT_ID }}"}'
+          client-id: ${{ secrets.AAD_CLIENT_ID }}
+          tenant-id: ${{ secrets.AAD_TENANT_ID }}
+          subscription-id: ${{ secrets.AAD_SUBSCRIPTION_ID }}
 
       - name: Delete existing container group
         run: |


### PR DESCRIPTION
The initial PR #1114 merged with the old `creds:` service principal secret format. This PR adds the OIDC federated credential auth that was already committed to `staging`.

Changes: remove `clientSecret` from `azure/login`, add `permissions: id-token: write`.