### PR TITLE
Fix az container create command flags

### DIFF
--- a/.github/workflows/main_nihgithubportalcb.yml
+++ b/.github/workflows/main_nihgithubportalcb.yml
@@ -50,7 +50,7 @@ jobs:
             --name nihgithubportalcb \
             --location centralus \
             --image "$REGISTRY_SERVER/portal:latest" \
-            --registry-server "$REGISTRY_SERVER" \
+            --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \
             --registry-password "$REGISTRY_PASS" \
             --command-line "node /usr/src/repos/jobs/refreshQueryCache.js" \
@@ -74,9 +74,5 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_APP_OPERATIONS_KEY="$APP_KEY" \
-            --tags \
-              'Creator=petersonjd@nih.gov' \
-              Customer=NIH \
-              Impact=Low \
-              Project=GitHub \
+            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait

--- a/.github/workflows/main_nihgithubportalfh.yml
+++ b/.github/workflows/main_nihgithubportalfh.yml
@@ -48,7 +48,7 @@ jobs:
             --name nihgithubportalfh \
             --location centralus \
             --image "$REGISTRY_SERVER/portal:latest" \
-            --registry-server "$REGISTRY_SERVER" \
+            --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \
             --registry-password "$REGISTRY_PASS" \
             --command-line "node /usr/src/repos/jobs/firehose.js" \
@@ -73,9 +73,5 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_WEBHOOKS_SERVICEBUS_CONNECTIONSTRING="$SERVICEBUS_CONN" \
-            --tags \
-              'Creator=petersonjd@nih.gov' \
-              Customer=NIH \
-              Impact=Low \
-              Project=GitHub \
+            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait

--- a/.github/workflows/staging_nihdevgithubportalcb.yml
+++ b/.github/workflows/staging_nihdevgithubportalcb.yml
@@ -50,7 +50,7 @@ jobs:
             --name nihdevgithubportalcb \
             --location centralus \
             --image "$REGISTRY_SERVER/portal:latest" \
-            --registry-server "$REGISTRY_SERVER" \
+            --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \
             --registry-password "$REGISTRY_PASS" \
             --command-line "node /usr/src/repos/jobs/refreshQueryCache.js" \
@@ -74,9 +74,5 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_APP_OPERATIONS_KEY="$APP_KEY" \
-            --tags \
-              'Creator=petersonjd@nih.gov' \
-              Customer=NIH \
-              Impact=Low \
-              Project=GitHub \
+            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait

--- a/.github/workflows/staging_nihdevgithubportalfh.yml
+++ b/.github/workflows/staging_nihdevgithubportalfh.yml
@@ -48,7 +48,7 @@ jobs:
             --name nihdevgithubportalfh \
             --location centralus \
             --image "$REGISTRY_SERVER/portal:latest" \
-            --registry-server "$REGISTRY_SERVER" \
+            --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \
             --registry-password "$REGISTRY_PASS" \
             --command-line "node /usr/src/repos/jobs/firehose.js" \
@@ -73,9 +73,5 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_WEBHOOKS_SERVICEBUS_CONNECTIONSTRING="$SERVICEBUS_CONN" \
-            --tags \
-              'Creator=petersonjd@nih.gov' \
-              Customer=NIH \
-              Impact=Low \
-              Project=GitHub \
+            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve consistency and compatibility with Azure CLI commands. The main changes involve updating parameter names for container registry authentication and simplifying how tags are specified when deploying resources.

**Azure CLI parameter updates:**

- Replaced the deprecated `--registry-server` parameter with `--registry-login-server` in the `az container create` commands across all relevant workflow files. [[1]](diffhunk://#diff-73c5970f42d607d4479fafa906bd2e6df500ff0aebf7d9f763418e8cd0f70701L53-R53) [[2]](diffhunk://#diff-fd2274688238ed27cedabb4fca5d3955fd0b5a1e25b541c2d5a5d7b351e4fd3dL51-R51) [[3]](diffhunk://#diff-30e27e6b1773c9cfca25c42f1f937e20c7d71b8cc50e544bdc2f8fe6c0320fc5L53-R53) [[4]](diffhunk://#diff-2b626a8e6b11a38f57c2c30db7aa137ef734c2c8fe957d4216fbee453ea3794cL51-R51)

**Tag specification simplification:**

- Consolidated multi-line `--tags` arguments into a single line for better readability and to prevent potential parsing issues in all deployment steps. [[1]](diffhunk://#diff-73c5970f42d607d4479fafa906bd2e6df500ff0aebf7d9f763418e8cd0f70701L77-R77) [[2]](diffhunk://#diff-fd2274688238ed27cedabb4fca5d3955fd0b5a1e25b541c2d5a5d7b351e4fd3dL76-R76) [[3]](diffhunk://#diff-30e27e6b1773c9cfca25c42f1f937e20c7d71b8cc50e544bdc2f8fe6c0320fc5L77-R77) [[4]](diffhunk://#diff-2b626a8e6b11a38f57c2c30db7aa137ef734c2c8fe957d4216fbee453ea3794cL76-R76)