### PR TITLE
Fix --tags flag handling in az container create command

### DIFF
--- a/.github/workflows/main_nihgithubportalcb.yml
+++ b/.github/workflows/main_nihgithubportalcb.yml
@@ -74,5 +74,4 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_APP_OPERATIONS_KEY="$APP_KEY" \
-            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait

--- a/.github/workflows/main_nihgithubportalcb.yml
+++ b/.github/workflows/main_nihgithubportalcb.yml
@@ -60,6 +60,7 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
+            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \

--- a/.github/workflows/main_nihgithubportalfh.yml
+++ b/.github/workflows/main_nihgithubportalfh.yml
@@ -73,5 +73,4 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_WEBHOOKS_SERVICEBUS_CONNECTIONSTRING="$SERVICEBUS_CONN" \
-            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait

--- a/.github/workflows/main_nihgithubportalfh.yml
+++ b/.github/workflows/main_nihgithubportalfh.yml
@@ -58,6 +58,7 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
+            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \

--- a/.github/workflows/staging_nihdevgithubportalcb.yml
+++ b/.github/workflows/staging_nihdevgithubportalcb.yml
@@ -74,5 +74,4 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_APP_OPERATIONS_KEY="$APP_KEY" \
-            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait

--- a/.github/workflows/staging_nihdevgithubportalcb.yml
+++ b/.github/workflows/staging_nihdevgithubportalcb.yml
@@ -60,6 +60,7 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
+            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \

--- a/.github/workflows/staging_nihdevgithubportalfh.yml
+++ b/.github/workflows/staging_nihdevgithubportalfh.yml
@@ -73,5 +73,4 @@ jobs:
               REDIS_KEY="$REDIS_KEY" \
               REPOS_POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
               GITHUB_WEBHOOKS_SERVICEBUS_CONNECTIONSTRING="$SERVICEBUS_CONN" \
-            --tags 'Creator=petersonjd@nih.gov' Customer=NIH Impact=Low Project=GitHub \
             --no-wait

--- a/.github/workflows/staging_nihdevgithubportalfh.yml
+++ b/.github/workflows/staging_nihdevgithubportalfh.yml
@@ -58,6 +58,7 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
+            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \


### PR DESCRIPTION
This pull request standardizes the way resource tags are set in the deployment steps of several GitHub Actions workflow files. The main change is to move the `--tags` argument to a consistent position before the `--environment-variables` argument and to remove unnecessary single quotes around the tag values.

Tagging standardization in deployment workflows:

* Updated the `--tags` argument in all affected workflow files to appear before `--environment-variables`, ensuring a consistent order in deployment commands. [[1]](diffhunk://#diff-73c5970f42d607d4479fafa906bd2e6df500ff0aebf7d9f763418e8cd0f70701R63) [[2]](diffhunk://#diff-fd2274688238ed27cedabb4fca5d3955fd0b5a1e25b541c2d5a5d7b351e4fd3dR61) [[3]](diffhunk://#diff-30e27e6b1773c9cfca25c42f1f937e20c7d71b8cc50e544bdc2f8fe6c0320fc5R63) [[4]](diffhunk://#diff-2b626a8e6b11a38f57c2c30db7aa137ef734c2c8fe957d4216fbee453ea3794cR61)
* Removed single quotes from around the tag values in the `--tags` argument for clarity and consistency. [[1]](diffhunk://#diff-73c5970f42d607d4479fafa906bd2e6df500ff0aebf7d9f763418e8cd0f70701L77) [[2]](diffhunk://#diff-fd2274688238ed27cedabb4fca5d3955fd0b5a1e25b541c2d5a5d7b351e4fd3dL76) [[3]](diffhunk://#diff-30e27e6b1773c9cfca25c42f1f937e20c7d71b8cc50e544bdc2f8fe6c0320fc5L77) [[4]](diffhunk://#diff-2b626a8e6b11a38f57c2c30db7aa137ef734c2c8fe957d4216fbee453ea3794cL76)