### PR TITLE
fix: remove --tags, not supported by az container create

### DIFF
--- a/.github/workflows/main_nihgithubportalcb.yml
+++ b/.github/workflows/main_nihgithubportalcb.yml
@@ -60,7 +60,6 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
-            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \

--- a/.github/workflows/main_nihgithubportalfh.yml
+++ b/.github/workflows/main_nihgithubportalfh.yml
@@ -58,7 +58,6 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
-            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \

--- a/.github/workflows/staging_nihdevgithubportalcb.yml
+++ b/.github/workflows/staging_nihdevgithubportalcb.yml
@@ -60,7 +60,6 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
-            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \

--- a/.github/workflows/staging_nihdevgithubportalfh.yml
+++ b/.github/workflows/staging_nihdevgithubportalfh.yml
@@ -58,7 +58,6 @@ jobs:
             --memory 1.5 \
             --ip-address Public \
             --ports 443 \
-            --tags Creator=petersonjd@nih.gov Customer=NIH Impact=Low Project=GitHub \
             --environment-variables \
               REDIS_TLS_HOST="$REDIS_TLS_HOST" \
               REDIS_PORT=6380 \


### PR DESCRIPTION
This pull request removes the Azure resource tag configuration from several GitHub Actions workflow files. The tags previously included metadata such as creator, customer, impact, and project, and their removal simplifies the deployment steps for these workflows.

Deployment workflow simplification:

* Removed the `--tags` parameter (which included `Creator`, `Customer`, `Impact`, and `Project` metadata) from the Azure deployment commands in the following workflow files:
  * `.github/workflows/main_nihgithubportalcb.yml`
  * `.github/workflows/main_nihgithubportalfh.yml`
  * `.github/workflows/staging_nihdevgithubportalcb.yml`
  * `.github/workflows/staging_nihdevgithubportalfh.yml`