### PR TITLE
infra: migrate Azure region from Central US to East US

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -38,6 +38,7 @@
   "useGitignore": true,
   "words": [
     "aztfexport",
+    "cutover",
     "nihgithubportaltf",
     "1es",
     "1escopilot",

--- a/.github/workflows/main_create_acr_image.yml
+++ b/.github/workflows/main_create_acr_image.yml
@@ -93,7 +93,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihgithubportalcb \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${{ github.sha }}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \
@@ -182,7 +182,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihgithubportalfh \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${{ github.sha }}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \

--- a/.github/workflows/main_nihgithubportalcb.yml
+++ b/.github/workflows/main_nihgithubportalcb.yml
@@ -59,7 +59,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihgithubportalcb \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${IMAGE_TAG}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \

--- a/.github/workflows/main_nihgithubportalfh.yml
+++ b/.github/workflows/main_nihgithubportalfh.yml
@@ -73,7 +73,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihgithubportalfh \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${IMAGE_TAG}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \

--- a/.github/workflows/staging_create_acr_image.yml
+++ b/.github/workflows/staging_create_acr_image.yml
@@ -105,7 +105,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihdevgithubportalcb \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${{ github.sha }}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \
@@ -195,7 +195,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihdevgithubportalfh \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${{ github.sha }}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \

--- a/.github/workflows/staging_nihdevgithubportalcb.yml
+++ b/.github/workflows/staging_nihdevgithubportalcb.yml
@@ -71,7 +71,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihdevgithubportalcb \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${IMAGE_TAG}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \

--- a/.github/workflows/staging_nihdevgithubportalfh.yml
+++ b/.github/workflows/staging_nihdevgithubportalfh.yml
@@ -73,7 +73,7 @@ jobs:
           az container create \
             --resource-group "$RG" \
             --name nihdevgithubportalfh \
-            --location centralus \
+            --location eastus \
             --image "$REGISTRY_SERVER/portal:${IMAGE_TAG}" \
             --registry-login-server "$REGISTRY_SERVER" \
             --registry-username "$REGISTRY_USER" \

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,6 +4,17 @@ Priority-ordered list of security improvements identified across this repository
 
 ---
 
+## Azure Region Migration: Central US → East US (August 2026)
+
+Moved the default Azure region for all Terraform-managed and ACI resources from `centralus` to `eastus`.
+
+- `infra/terraform/dev/variables.tf`, `infra/terraform/prod/variables.tf`: default `location` → `eastus`
+- ACI `--location` updated in `main_create_acr_image.yml`, `main_nihgithubportalcb.yml`, `main_nihgithubportalfh.yml`, `staging_create_acr_image.yml`, `staging_nihdevgithubportalcb.yml`, `staging_nihdevgithubportalfh.yml`
+
+**Known/accepted impact:** `location` is immutable on `azurerm_log_analytics_workspace`, `azurerm_servicebus_namespace`, and `azurerm_user_assigned_identity`, so `terraform apply` destroys and recreates these rather than moving them in place. Accepted trade-off: a short window (~15 minutes) of lost Log Analytics history and any in-flight Service Bus messages during cutover, versus a costlier migration later. `staging_terraform_dev.yml` auto-applies on push to `staging`, so dev migrates immediately on merge; prod only migrates once this reaches `main`. The ACI deploy workflows already delete the container group before recreating it, so there's no location-conflict error, and those containers are stateless (state lives in Postgres/Redis), so no data loss there.
+
+---
+
 ## GitHub Actions Secret Reduction (June 2026)
 
 Audit of all workflow secrets against Entra ID Workload Federation (OIDC) coverage.

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -6,7 +6,7 @@ variable "resource_group_name" {
 variable "location" {
   description = "Azure region for all resources"
   type        = string
-  default     = "centralus"
+  default     = "eastus"
 }
 
 variable "log_analytics_workspace_name" {

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -6,7 +6,7 @@ variable "resource_group_name" {
 variable "location" {
   description = "Azure region for all resources"
   type        = string
-  default     = "centralus"
+  default     = "eastus"
 }
 
 variable "log_analytics_workspace_name" {


### PR DESCRIPTION
## Summary

Migrates the default Azure region for all Terraform-managed and ACI resources from `centralus` to `eastus`.

- `infra/terraform/dev/variables.tf`, `infra/terraform/prod/variables.tf`: default `location` → `eastus`
- ACI `--location` updated in `main_create_acr_image.yml`, `main_nihgithubportalcb.yml`, `main_nihgithubportalfh.yml`, `staging_create_acr_image.yml`, `staging_nihdevgithubportalcb.yml`, `staging_nihdevgithubportalfh.yml`
- PLAN.md updated with a summary of the change and its known impact

## Impact / risk (accepted)

`location` is immutable on `azurerm_log_analytics_workspace`, `azurerm_servicebus_namespace`, and `azurerm_user_assigned_identity`, so `terraform apply` will destroy and recreate these rather than move them in place:

- Log Analytics workspace history is lost on recreation (no data migration)
- Service Bus namespace/queue recreation loses any in-flight messages during cutover
- Firehose managed identity is recreated with a new principal/client ID; the role assignment is reapplied by the same `terraform apply`

Accepted trade-off: an estimated ~15 minutes of lost telemetry/queue data during cutover now, versus a more expensive migration later.

## Rollout

- Dev already migrated: pushing to `staging` auto-applies `staging_terraform_dev.yml` (`terraform apply -auto-approve`), so the dev Log Analytics workspace and Service Bus namespace have already been recreated in East US.
- Merging this PR to `main` will trigger `main_terraform_prod.yml`, which will do the same for prod.
- ACI container workflows (`cb`/`fh`) are `workflow_dispatch`-only or gated by unrelated path filters, and already delete the container group before recreating it, so there's no location-conflict error. Containers are stateless (state lives in Postgres/Redis), so no data loss there — just a brief redeploy interruption whenever those workflows are next run.