### PR TITLE
Merge staging → main: Service Bus Webhook Fix, Log Analytics Wiring, and Tenant-Migration Log Redaction

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -662,6 +662,8 @@
     "nihgithubadmin",
     "nihgithubportal",
     "nihgithubportalcb",
+    "nihgithubportaldb",
+    "nihgithubportalevents",
     "nihgithubportalfh",
     "nihgithubportalsb",
     "noauth",

--- a/.cspell.json
+++ b/.cspell.json
@@ -664,6 +664,8 @@
     "nihgithubportalcb",
     "nihgithubportaldb",
     "nihgithubportalevents",
+    "repoint",
+    "repointed",
     "nihgithubportalfh",
     "nihgithubportalsb",
     "noauth",

--- a/.github/workflows/main_nihgithubportal.yml
+++ b/.github/workflows/main_nihgithubportal.yml
@@ -127,7 +127,9 @@ jobs:
       contents: read
     environment:
       name: 'Production'
-      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+      # azure/webapps-deploy's output is the raw *.azurewebsites.net hostname, not the custom
+      # domain (fronted by nihgithubportal-afd) that's actually public-facing.
+      url: 'https://portal.github.nih.gov'
 
     steps:
       - name: Download artifact from build job

--- a/.github/workflows/main_terraform_prod.yml
+++ b/.github/workflows/main_terraform_prod.yml
@@ -84,12 +84,26 @@ jobs:
       - name: Terraform Import
         if: ${{ github.event.inputs.action == 'import' }}
         working-directory: infra/terraform/prod
+        env:
+          IMPORT_ADDRESS: ${{ github.event.inputs.import_address }}
+          IMPORT_RESOURCE_ID: ${{ github.event.inputs.import_resource_id }}
         run: |
+          # Masked and validated, then passed as shell variables (never expression-interpolated
+          # into the script body) so a crafted value can't execute as shell code or leak in logs.
+          echo "::add-mask::$IMPORT_RESOURCE_ID"
+          if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_\[\]\"'-]*)+$ ]]; then
+            echo "::error::import_address does not look like a valid Terraform resource address"
+            exit 1
+          fi
+          if [[ ! "$IMPORT_RESOURCE_ID" =~ ^/subscriptions/[0-9a-fA-F-]+/ ]]; then
+            echo "::error::import_resource_id does not look like a valid Azure resource ID"
+            exit 1
+          fi
           terraform import \
             -var="resource_group_name=${{ secrets.PROD_RG }}" \
             -var="servicebus_namespace_name=${{ vars.PROD_SERVICEBUS_NAMESPACE }}" \
-            "${{ github.event.inputs.import_address }}" \
-            "${{ github.event.inputs.import_resource_id }}"
+            "$IMPORT_ADDRESS" \
+            "$IMPORT_RESOURCE_ID"
 
       - name: Terraform Plan
         working-directory: infra/terraform/prod

--- a/.github/workflows/main_terraform_prod.yml
+++ b/.github/workflows/main_terraform_prod.yml
@@ -16,6 +16,13 @@ on:
         options:
           - plan
           - apply
+          - import
+      import_address:
+        description: '[import only] Terraform resource address, e.g. azurerm_api_connection.servicebus'
+        required: false
+      import_resource_id:
+        description: '[import only] Full Azure resource ID to import into the address above'
+        required: false
 
 permissions:
   id-token: write
@@ -73,6 +80,16 @@ jobs:
             -backend-config="container_name=${{ vars.PROD_TF_STORAGE_CONTAINER }}" \
             -backend-config="key=prod/terraform.tfstate" \
             -backend-config="use_azuread_auth=true"
+
+      - name: Terraform Import
+        if: ${{ github.event.inputs.action == 'import' }}
+        working-directory: infra/terraform/prod
+        run: |
+          terraform import \
+            -var="resource_group_name=${{ secrets.PROD_RG }}" \
+            -var="servicebus_namespace_name=${{ vars.PROD_SERVICEBUS_NAMESPACE }}" \
+            "${{ github.event.inputs.import_address }}" \
+            "${{ github.event.inputs.import_resource_id }}"
 
       - name: Terraform Plan
         working-directory: infra/terraform/prod

--- a/.github/workflows/main_terraform_prod.yml
+++ b/.github/workflows/main_terraform_prod.yml
@@ -69,7 +69,7 @@ jobs:
             2>/dev/null || echo "Container already exists"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Terraform Init
         working-directory: infra/terraform/prod

--- a/.github/workflows/main_terraform_prod.yml
+++ b/.github/workflows/main_terraform_prod.yml
@@ -91,7 +91,7 @@ jobs:
           # Masked and validated, then passed as shell variables (never expression-interpolated
           # into the script body) so a crafted value can't execute as shell code or leak in logs.
           echo "::add-mask::$IMPORT_RESOURCE_ID"
-          if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_\[\]\"'-]*)+$ ]]; then
+          if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_-]*)+$ ]]; then
             echo "::error::import_address does not look like a valid Terraform resource address"
             exit 1
           fi

--- a/.github/workflows/main_terraform_prod.yml
+++ b/.github/workflows/main_terraform_prod.yml
@@ -88,17 +88,18 @@ jobs:
           IMPORT_ADDRESS: ${{ github.event.inputs.import_address }}
           IMPORT_RESOURCE_ID: ${{ github.event.inputs.import_resource_id }}
         run: |
-          # Masked and validated, then passed as shell variables (never expression-interpolated
-          # into the script body) so a crafted value can't execute as shell code or leak in logs.
-          echo "::add-mask::$IMPORT_RESOURCE_ID"
+          # Validated as complete, single-line data BEFORE emitting any workflow command --
+          # add-mask on an unvalidated value would let an embedded newline inject a second Actions
+          # command and leave part of the value unmasked, since add-mask only covers up to that break.
           if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_-]*)+$ ]]; then
             echo "::error::import_address does not look like a valid Terraform resource address"
             exit 1
           fi
-          if [[ ! "$IMPORT_RESOURCE_ID" =~ ^/subscriptions/[0-9a-fA-F-]+/ ]]; then
+          if [[ ! "$IMPORT_RESOURCE_ID" =~ ^/subscriptions/[0-9a-fA-F-]+/resourceGroups/[A-Za-z0-9._-]+/providers/[A-Za-z0-9.]+(/[A-Za-z0-9._-]+)+$ ]]; then
             echo "::error::import_resource_id does not look like a valid Azure resource ID"
             exit 1
           fi
+          echo "::add-mask::$IMPORT_RESOURCE_ID"
           terraform import \
             -var="resource_group_name=${{ secrets.PROD_RG }}" \
             -var="servicebus_namespace_name=${{ vars.PROD_SERVICEBUS_NAMESPACE }}" \

--- a/.github/workflows/staging_nihdevgithubportal.yml
+++ b/.github/workflows/staging_nihdevgithubportal.yml
@@ -126,7 +126,7 @@ jobs:
       id-token: write
       contents: read
     environment:
-      name: 'Production'
+      name: 'Development'
       url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
 
     steps:

--- a/.github/workflows/staging_nihdevgithubportal.yml
+++ b/.github/workflows/staging_nihdevgithubportal.yml
@@ -127,7 +127,9 @@ jobs:
       contents: read
     environment:
       name: 'Development'
-      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+      # azure/webapps-deploy's output is the raw *.azurewebsites.net hostname, not the custom
+      # domain (fronted by nihdevgithubportal-afd) that's actually public-facing.
+      url: 'https://dev.portal.github.nih.gov'
 
     steps:
       - name: Download artifact from build job

--- a/.github/workflows/staging_terraform_dev.yml
+++ b/.github/workflows/staging_terraform_dev.yml
@@ -91,17 +91,18 @@ jobs:
           IMPORT_ADDRESS: ${{ github.event.inputs.import_address }}
           IMPORT_RESOURCE_ID: ${{ github.event.inputs.import_resource_id }}
         run: |
-          # Masked and validated, then passed as shell variables (never expression-interpolated
-          # into the script body) so a crafted value can't execute as shell code or leak in logs.
-          echo "::add-mask::$IMPORT_RESOURCE_ID"
+          # Validated as complete, single-line data BEFORE emitting any workflow command --
+          # add-mask on an unvalidated value would let an embedded newline inject a second Actions
+          # command and leave part of the value unmasked, since add-mask only covers up to that break.
           if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_-]*)+$ ]]; then
             echo "::error::import_address does not look like a valid Terraform resource address"
             exit 1
           fi
-          if [[ ! "$IMPORT_RESOURCE_ID" =~ ^/subscriptions/[0-9a-fA-F-]+/ ]]; then
+          if [[ ! "$IMPORT_RESOURCE_ID" =~ ^/subscriptions/[0-9a-fA-F-]+/resourceGroups/[A-Za-z0-9._-]+/providers/[A-Za-z0-9.]+(/[A-Za-z0-9._-]+)+$ ]]; then
             echo "::error::import_resource_id does not look like a valid Azure resource ID"
             exit 1
           fi
+          echo "::add-mask::$IMPORT_RESOURCE_ID"
           terraform import \
             -var="resource_group_name=${{ secrets.DEV_RG }}" \
             -var="servicebus_namespace_name=${{ vars.DEV_SERVICEBUS_NAMESPACE }}" \

--- a/.github/workflows/staging_terraform_dev.yml
+++ b/.github/workflows/staging_terraform_dev.yml
@@ -72,7 +72,7 @@ jobs:
             2>/dev/null || echo "Container already exists"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
 
       - name: Terraform Init
         working-directory: infra/terraform/dev

--- a/.github/workflows/staging_terraform_dev.yml
+++ b/.github/workflows/staging_terraform_dev.yml
@@ -87,12 +87,26 @@ jobs:
       - name: Terraform Import
         if: ${{ github.event.inputs.action == 'import' }}
         working-directory: infra/terraform/dev
+        env:
+          IMPORT_ADDRESS: ${{ github.event.inputs.import_address }}
+          IMPORT_RESOURCE_ID: ${{ github.event.inputs.import_resource_id }}
         run: |
+          # Masked and validated, then passed as shell variables (never expression-interpolated
+          # into the script body) so a crafted value can't execute as shell code or leak in logs.
+          echo "::add-mask::$IMPORT_RESOURCE_ID"
+          if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_\[\]\"'-]*)+$ ]]; then
+            echo "::error::import_address does not look like a valid Terraform resource address"
+            exit 1
+          fi
+          if [[ ! "$IMPORT_RESOURCE_ID" =~ ^/subscriptions/[0-9a-fA-F-]+/ ]]; then
+            echo "::error::import_resource_id does not look like a valid Azure resource ID"
+            exit 1
+          fi
           terraform import \
             -var="resource_group_name=${{ secrets.DEV_RG }}" \
             -var="servicebus_namespace_name=${{ vars.DEV_SERVICEBUS_NAMESPACE }}" \
-            "${{ github.event.inputs.import_address }}" \
-            "${{ github.event.inputs.import_resource_id }}"
+            "$IMPORT_ADDRESS" \
+            "$IMPORT_RESOURCE_ID"
 
       - name: Terraform Plan
         working-directory: infra/terraform/dev

--- a/.github/workflows/staging_terraform_dev.yml
+++ b/.github/workflows/staging_terraform_dev.yml
@@ -16,6 +16,13 @@ on:
         options:
           - plan
           - apply
+          - import
+      import_address:
+        description: '[import only] Terraform resource address, e.g. azurerm_api_connection.servicebus'
+        required: false
+      import_resource_id:
+        description: '[import only] Full Azure resource ID to import into the address above'
+        required: false
 
 permissions:
   id-token: write
@@ -76,6 +83,16 @@ jobs:
             -backend-config="container_name=${{ vars.DEV_TF_STORAGE_CONTAINER }}" \
             -backend-config="key=dev/terraform.tfstate" \
             -backend-config="use_azuread_auth=true"
+
+      - name: Terraform Import
+        if: ${{ github.event.inputs.action == 'import' }}
+        working-directory: infra/terraform/dev
+        run: |
+          terraform import \
+            -var="resource_group_name=${{ secrets.DEV_RG }}" \
+            -var="servicebus_namespace_name=${{ vars.DEV_SERVICEBUS_NAMESPACE }}" \
+            "${{ github.event.inputs.import_address }}" \
+            "${{ github.event.inputs.import_resource_id }}"
 
       - name: Terraform Plan
         working-directory: infra/terraform/dev

--- a/.github/workflows/staging_terraform_dev.yml
+++ b/.github/workflows/staging_terraform_dev.yml
@@ -94,7 +94,7 @@ jobs:
           # Masked and validated, then passed as shell variables (never expression-interpolated
           # into the script body) so a crafted value can't execute as shell code or leak in logs.
           echo "::add-mask::$IMPORT_RESOURCE_ID"
-          if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_\[\]\"'-]*)+$ ]]; then
+          if [[ ! "$IMPORT_ADDRESS" =~ ^[A-Za-z_][A-Za-z0-9_-]*(\.[A-Za-z_][A-Za-z0-9_-]*)+$ ]]; then
             echo "::error::import_address does not look like a valid Terraform resource address"
             exit 1
           fi

--- a/.github/workflows/tenant_migration.yml
+++ b/.github/workflows/tenant_migration.yml
@@ -153,10 +153,15 @@ jobs:
             --resource-group "$RG" \
             --workspace-name "$LOG_ANALYTICS_WORKSPACE" \
             --query primarySharedKey --output tsv 2>/dev/null || echo "")
-          LA_ARGS=()
-          if [ -n "$LA_WORKSPACE_ID" ]; then
-            LA_ARGS=(--log-analytics-workspace "$LA_WORKSPACE_ID" --log-analytics-workspace-key "$LA_WORKSPACE_KEY")
+          # Fatal rather than silently launching without a diagnostics sink: since the raw
+          # container log is never printed publicly (corporate-identity data), Log Analytics is
+          # the only place a failed run's output survives after the container is deleted below.
+          if [ -z "$LA_WORKSPACE_ID" ] || [ -z "$LA_WORKSPACE_KEY" ]; then
+            echo "::error::Could not resolve Log Analytics workspace '$LOG_ANALYTICS_WORKSPACE' -- refusing to launch a container with no diagnostics sink"
+            exit 1
           fi
+          LA_ARGS=(--log-analytics-workspace "$LA_WORKSPACE_ID" --log-analytics-workspace-key "$LA_WORKSPACE_KEY")
+
 
           ACR_NAME="${REGISTRY_SERVER%%.*}"
           IMAGE_TAG="$IMAGE_TAG_INPUT"

--- a/.github/workflows/tenant_migration.yml
+++ b/.github/workflows/tenant_migration.yml
@@ -274,7 +274,7 @@ jobs:
                 -e 's/^([[:space:]]*(before|after):).*/\1 [REDACTED]/' \
                 -e 's/^.* toggled (for link|back to original value for) .*/[REDACTED]/' \
                 -e 's/(marked ready) -> .*/\1 [REDACTED]/' \
-                -e 's/\(live:[^)]*\)/(redacted)/g'
+                -e 's/\(live:.*/(redacted)/'
 
           EXIT_CODE=$(az container show --resource-group "$RG" --name "$CONTAINER_NAME" \
             --query "containers[0].instanceView.currentState.exitCode" --output tsv 2>/dev/null || echo "1")

--- a/.github/workflows/tenant_migration.yml
+++ b/.github/workflows/tenant_migration.yml
@@ -213,7 +213,12 @@ jobs:
               ;;
           esac
 
+          # --output none: az container create's own JSON response echoes back the plain
+          # (non-secure) environment variables it was given -- including any UPN/display-name
+          # filter substrings -- which would otherwise land in this public job log. Errors still
+          # go to stderr regardless of --output.
           az container create \
+            --output none \
             --resource-group "$RG" \
             --name "$CONTAINER_NAME" \
             --location eastus \
@@ -291,7 +296,7 @@ jobs:
           BATCH_ID_INPUT: ${{ inputs.batch_id }}
         run: |
           if ! grep -q '===TENANT_MIGRATION_CANDIDATES_JSON_BEGIN===' container.log; then
-            echo "::error::Could not find the candidates JSON marker in the container logs -- see logs above"
+            echo "::error::Could not find the candidates JSON marker -- see Log Analytics for the container's full output"
             exit 1
           fi
           sed -n '/===TENANT_MIGRATION_CANDIDATES_JSON_BEGIN===/,/===TENANT_MIGRATION_CANDIDATES_JSON_END===/p' container.log \
@@ -301,12 +306,32 @@ jobs:
           # uploaded artifact instead.
           echo "Wrote $(wc -l < "candidates-${BATCH_ID_INPUT}.json") line(s) to candidates-${BATCH_ID_INPUT}.json"
 
+      - name: Encrypt candidates JSON (gather mode)
+        if: inputs.mode == 'gather'
+        env:
+          BATCH_ID_INPUT: ${{ inputs.batch_id }}
+          ARTIFACT_PASSPHRASE: ${{ secrets.TENANT_MIGRATION_ARTIFACT_PASSPHRASE }}
+        run: |
+          # On a public repo, any signed-in GitHub user (not just this org) has read access and can
+          # download workflow run artifacts -- an unencrypted artifact would expose this batch's
+          # corporate-identity candidates the same way printing it to the log would. Decrypt locally
+          # with the same passphrase before editing:
+          #   openssl enc -d -aes-256-cbc -pbkdf2 -pass env:TENANT_MIGRATION_ARTIFACT_PASSPHRASE \
+          #     -in candidates-<batch>.json.enc -out candidates-<batch>.json
+          if [ -z "$ARTIFACT_PASSPHRASE" ]; then
+            echo "::error::TENANT_MIGRATION_ARTIFACT_PASSPHRASE secret is not set -- refusing to upload an unencrypted candidates artifact"
+            exit 1
+          fi
+          openssl enc -aes-256-cbc -pbkdf2 -pass env:ARTIFACT_PASSPHRASE \
+            -in "candidates-${BATCH_ID_INPUT}.json" -out "candidates-${BATCH_ID_INPUT}.json.enc"
+          rm -f "candidates-${BATCH_ID_INPUT}.json"
+
       - name: Upload candidates artifact (gather mode)
         if: inputs.mode == 'gather'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tenant-migration-candidates-${{ inputs.batch_id }}
-          path: candidates-${{ inputs.batch_id }}.json
+          path: candidates-${{ inputs.batch_id }}.json.enc
           retention-days: 14
 
       - name: Check outcome

--- a/.github/workflows/tenant_migration.yml
+++ b/.github/workflows/tenant_migration.yml
@@ -274,7 +274,9 @@ jobs:
                 -e 's/^([[:space:]]*(before|after):).*/\1 [REDACTED]/' \
                 -e 's/^.* toggled (for link|back to original value for) .*/[REDACTED]/' \
                 -e 's/(marked ready) -> .*/\1 [REDACTED]/' \
-                -e 's/\(live:.*/(redacted)/'
+                -e 's/\(live:.*/(redacted)/' \
+                -e 's/(newCorporateId does not look like a GUID:).*/\1 [REDACTED]/' \
+                -e 's/(newCorporateUsername does not look like a valid UPN:).*/\1 [REDACTED]/'
 
           EXIT_CODE=$(az container show --resource-group "$RG" --name "$CONTAINER_NAME" \
             --query "containers[0].instanceView.currentState.exitCode" --output tsv 2>/dev/null || echo "1")

--- a/.github/workflows/tenant_migration.yml
+++ b/.github/workflows/tenant_migration.yml
@@ -265,8 +265,16 @@ jobs:
           done
 
           az container logs --resource-group "$RG" --name "$CONTAINER_NAME" > container.log 2>&1 || true
-          echo "--- container logs (candidate JSON, if any, is redacted here -- see the uploaded artifact) ---"
-          sed '/===TENANT_MIGRATION_CANDIDATES_JSON_BEGIN===/,/===TENANT_MIGRATION_CANDIDATES_JSON_END===/c\[REDACTED -- candidate corporate-identity data omitted from workflow logs]' container.log
+          echo "--- container logs ---"
+          # Removing logs from public view.
+          sed '/===TENANT_MIGRATION_CANDIDATES_JSON_BEGIN===/,/===TENANT_MIGRATION_CANDIDATES_JSON_END===/c\[REDACTED]' container.log \
+            | sed -E \
+                -e 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/[REDACTED]/g' \
+                -e 's/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/[REDACTED]/g' \
+                -e 's/^([[:space:]]*(before|after):).*/\1 [REDACTED]/' \
+                -e 's/^.* toggled (for link|back to original value for) .*/[REDACTED]/' \
+                -e 's/(marked ready) -> .*/\1 [REDACTED]/' \
+                -e 's/\(live:[^)]*\)/(redacted)/g'
 
           EXIT_CODE=$(az container show --resource-group "$RG" --name "$CONTAINER_NAME" \
             --query "containers[0].instanceView.currentState.exitCode" --output tsv 2>/dev/null || echo "1")

--- a/.github/workflows/tenant_migration.yml
+++ b/.github/workflows/tenant_migration.yml
@@ -265,18 +265,11 @@ jobs:
           done
 
           az container logs --resource-group "$RG" --name "$CONTAINER_NAME" > container.log 2>&1 || true
-          echo "--- container logs ---"
-          # Removing logs from public view.
-          sed '/===TENANT_MIGRATION_CANDIDATES_JSON_BEGIN===/,/===TENANT_MIGRATION_CANDIDATES_JSON_END===/c\[REDACTED]' container.log \
-            | sed -E \
-                -e 's/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/[REDACTED]/g' \
-                -e 's/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/[REDACTED]/g' \
-                -e 's/^([[:space:]]*(before|after):).*/\1 [REDACTED]/' \
-                -e 's/^.* toggled (for link|back to original value for) .*/[REDACTED]/' \
-                -e 's/(marked ready) -> .*/\1 [REDACTED]/' \
-                -e 's/\(live:.*/(redacted)/' \
-                -e 's/(newCorporateId does not look like a GUID:).*/\1 [REDACTED]/' \
-                -e 's/(newCorporateUsername does not look like a valid UPN:).*/\1 [REDACTED]/'
+          # container.log is not echoed here. Line-oriented redaction can't safely handle free-form
+          # corporate-identity values (they can contain literal newlines, defeating per-line
+          # patterns), so the raw log is kept off this public job log entirely. It's still available
+          # to the next step (candidate extraction) and, once applied, via Log Analytics.
+          echo "--- container logs are not echoed to this public workflow log; see Log Analytics ---"
 
           EXIT_CODE=$(az container show --resource-group "$RG" --name "$CONTAINER_NAME" \
             --query "containers[0].instanceView.currentState.exitCode" --output tsv 2>/dev/null || echo "1")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 Notes for AI coding agents working on this repository.
 
+## Public repo — mind what gets published
+
+This repo (code, commits, Actions run logs, workflow logs, issues, PRs, discussions) is **public**.
+Anything written to a file, printed in a workflow log, or posted to an issue/PR is world-readable.
+Before adding logging, committing data files, or posting anywhere in this repo, check whether it
+would expose anything that shouldn't be public (credentials, internal identifiers, personal data,
+infrastructure details, etc.), and flag it to the user rather than assuming it's fine. If a request
+would cause information to leak into a public surface, say so before proceeding.
+
 ## Dev environment
 
 - **Package manager:** bun only. Never `npm install`. Lockfile: `bun.lock`.

--- a/PLAN.md
+++ b/PLAN.md
@@ -18,17 +18,36 @@ Priority-ordered list of security improvements identified across this repository
   pre-existing `servicebus` connection so Terraform can repoint its connection string, without
   touching the Logic App's own definition — `infra/terraform/{dev,prod}/main.tf`. Also fixed a
   `managed_api_id` region mismatch (dev's connection was created in `centralus`, not `eastus`) that
-  was forcing an unwanted destroy/recreate instead of an in-place update.
+  was forcing an unwanted destroy/recreate instead of an in-place update. Since Azure never returns
+  the secure `connectionString` on refresh, added `lifecycle { ignore_changes = [parameter_values] }`
+  on dev (already repointed and verified via a clean `plan`) once confirmed; prod's is deferred to a
+  follow-up commit until after its own first repoint apply, so the initial value actually gets set.
 - **Wired Log Analytics into every other Azure resource** that wasn't already covered (App Service,
   PostgreSQL Flexible Server, Redis Cache, Container Registry, and the Terraform-managed Service Bus
   namespace) via `azurerm_monitor_diagnostic_setting`, referencing the existing resources through
   data sources rather than importing/managing them — `infra/terraform/{dev,prod}/main.tf`.
-- **Redacted corporate-identity data from the public `tenant_migration.yml` workflow log**:
-  `applyMigration.ts`/`setTargets.ts` and the shared link-provider's column-change logging print
-  full corporate GUIDs, emails, and display names to stdout; only the gather-mode candidates-JSON
-  block was previously redacted, leaving patch-mode runs fully exposed in this repo's world-readable
-  Actions logs. Now scrubs GUIDs, emails, corporate-identity snapshot lines, and drift-comparison
-  details from what's echoed into the job log.
+- **Stopped echoing the tenant-migration container's raw log to the public `tenant_migration.yml`
+  job log entirely.** An initial per-line `sed` redaction pass (scrubbing GUIDs, emails,
+  corporate-identity snapshot lines, drift-comparison details, and validation-error messages) turned
+  out to be fundamentally unsound: free-form corporate-identity values can contain literal newlines,
+  which defeats any line-oriented pattern. `container.log` is still written to disk for the
+  candidate-extraction step; nothing from the container's stdout is printed publicly anymore.
+- Made the tenant-migration container's Log Analytics workspace lookup **fail fast** instead of
+  silently launching with no diagnostics sink on failure — since the raw log is no longer echoed
+  anywhere, Log Analytics was the only remaining place a failed run's output could be inspected, so
+  a silent lookup failure meant a patch-mode failure left nothing recoverable but an exit code.
+- Fixed a real Bash syntax bug in the `import_address` validation regex (an unescaped apostrophe
+  inside an unquoted `=~` pattern opened an unterminated single-quoted string), which broke every
+  `terraform import` dispatch before it could run; verified the fix locally against both a valid
+  address and an injection attempt.
+- Fixed a misleading `environment: name: 'Production'` label on `staging_nihdevgithubportal.yml`
+  (the dev app deploy workflow) — copy-pasted from the real prod deploy workflow without renaming,
+  even though it deploys `nihdevgithubportal`. Renamed to `'Development'`; required an accompanying
+  Entra ID federated-credential update since this workflow's OIDC trust is bound to the GitHub
+  environment name, not just the branch ref (a real functional dependency, not just cosmetic).
+- Fixed both app deploy workflows' `environment.url` pointing at the raw
+  `azurewebsites.net` hostname (`azure/webapps-deploy`'s output) instead of the actual public custom
+  domain (`dev.portal.github.nih.gov` / `portal.github.nih.gov`).
 - Added a `terraform import` action (plus masked/validated `import_address`/`import_resource_id`
   inputs, passed as env vars rather than interpolated into the script) to both Terraform workflows,
   so `terraform import` can be run entirely through Actions instead of requiring local/Cloud Shell
@@ -38,6 +57,13 @@ Priority-ordered list of security improvements identified across this repository
 - Added a "this repo is public" note to `AGENTS.md` — code, commits, Actions logs, issues, and PRs
   are all world-readable; flag anything that would leak credentials/PII/infra details before
   proceeding.
+- Separately: Azure Portal's federated-credential UI started defaulting to "immutable" (org-ID/
+  repo-ID-based) OIDC subjects that GitHub Actions doesn't send by default, breaking Azure login for
+  any credential created through the Portal's default template in the last ~week
+  ([Azure/login#617](https://github.com/Azure/login/issues/617)). Fixed by enabling "Use immutable
+  subject claim" under this repo's Settings → Actions → OIDC and updating the affected federated
+  credentials to match; verified across all four distinct (app, subject) pairings used across the
+  repo's workflows (dev/prod × ref-based/environment-based).
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -4,6 +4,43 @@ Priority-ordered list of security improvements identified across this repository
 
 ---
 
+## Log Analytics wiring, Service Bus webhook fix, and log redaction (August 2026)
+
+- **Fixed a real webhook-delivery gap**: the `nihdevgithubportal`/`nihgithubportalevents` Logic
+  App (the sole GitHub → Service Bus publishing path per `docs/webhooks.md`) was still wired to the
+  pre-migration Service Bus namespace's `events` queue via its `servicebus` API connection —
+  firehose moved to the new `nihdevgithubportalsb`/`nihgithubportalsb` namespace during the June
+  2026 managed-identity migration, but this connection was never repointed. Confirmed via matching
+  `X-Ms-Workflow-Id`/`X-Ms-Workflow-Run-Id` headers from a live GitHub webhook delivery against the
+  Logic App's run history. Dev's orphaned queue had accumulated 58 active + 1198 dead-lettered
+  messages; prod had 620 active. Fixed by adding a send-only
+  `azurerm_servicebus_queue_authorization_rule` on the existing `events` queue and importing the
+  pre-existing `servicebus` connection so Terraform can repoint its connection string, without
+  touching the Logic App's own definition — `infra/terraform/{dev,prod}/main.tf`. Also fixed a
+  `managed_api_id` region mismatch (dev's connection was created in `centralus`, not `eastus`) that
+  was forcing an unwanted destroy/recreate instead of an in-place update.
+- **Wired Log Analytics into every other Azure resource** that wasn't already covered (App Service,
+  PostgreSQL Flexible Server, Redis Cache, Container Registry, and the Terraform-managed Service Bus
+  namespace) via `azurerm_monitor_diagnostic_setting`, referencing the existing resources through
+  data sources rather than importing/managing them — `infra/terraform/{dev,prod}/main.tf`.
+- **Redacted corporate-identity data from the public `tenant_migration.yml` workflow log**:
+  `applyMigration.ts`/`setTargets.ts` and the shared link-provider's column-change logging print
+  full corporate GUIDs, emails, and display names to stdout; only the gather-mode candidates-JSON
+  block was previously redacted, leaving patch-mode runs fully exposed in this repo's world-readable
+  Actions logs. Now scrubs GUIDs, emails, corporate-identity snapshot lines, and drift-comparison
+  details from what's echoed into the job log.
+- Added a `terraform import` action (plus masked/validated `import_address`/`import_resource_id`
+  inputs, passed as env vars rather than interpolated into the script) to both Terraform workflows,
+  so `terraform import` can be run entirely through Actions instead of requiring local/Cloud Shell
+  access.
+- Bumped `hashicorp/setup-terraform` to v4.0.1 (native Node 24, drops the Node 20 deprecation
+  warning).
+- Added a "this repo is public" note to `AGENTS.md` — code, commits, Actions logs, issues, and PRs
+  are all world-readable; flag anything that would leak credentials/PII/infra details before
+  proceeding.
+
+---
+
 ## Fixed missing Log Analytics wiring for `nihgithubportalcb` (August 2026)
 
 Azure Portal's Monitoring > Logs showed the Log Analytics workspace for `nihgithubportalfh` but

--- a/PLAN.md
+++ b/PLAN.md
@@ -783,13 +783,21 @@ gh workflow run tenant_migration.yml \
   -f exclude_upn_contains=<target-tenant-domain>
 ```
 
-This writes every match to the ledger table (never to `links`), and also uploads a **downloadable
-artifact** on the workflow run named `tenant-migration-candidates-<batch-id>` — a JSON file with
-one entry per candidate, pre-filled with their discovered identity and blank `new*` fields:
+This writes every match to the ledger table (never to `links`), and also uploads a **downloadable,
+encrypted artifact** on the workflow run named `tenant-migration-candidates-<batch-id>` -- an
+AES-256-CBC-encrypted JSON file (`candidates-<batch-id>.json.enc`), one entry per candidate,
+pre-filled with their discovered identity and blank `new*` fields. Encrypted because on this
+public repo, artifact downloads only require repo read access -- any signed-in GitHub user, not
+just this org:
 
 ```bash
 gh run download <run-id> -n tenant-migration-candidates-<batch-id>
+openssl enc -d -aes-256-cbc -pbkdf2 -pass env:TENANT_MIGRATION_ARTIFACT_PASSPHRASE \
+  -in candidates-<batch-id>.json.enc -out candidates-<batch-id>.json
 ```
+
+(`TENANT_MIGRATION_ARTIFACT_PASSPHRASE` is the same repo secret the workflow encrypts with --
+get it from whoever manages this repo's secrets, not from the workflow run itself.)
 
 Edit that file: for each person you want to migrate, fill in `newCorporateId` (their OID in the
 target tenant — get this from `az ad user show --id user@target-tenant.example --query id -o tsv`
@@ -818,8 +826,9 @@ gh workflow run tenant_migration.yml \
 ```
 
 This first records your edited target identities in the ledger (moving edited rows to `ready`,
-skipping any row you left blank), then applies them to `links` — dry run by default; review the
-printed before/after diff in the workflow run's logs, then re-run with `-f commit=true`
+skipping any row you left blank), then applies them to `links` — dry run by default; the
+container's own output (the before/after diff) is not echoed to this public workflow log --
+check Log Analytics for the run's `GITHUB_RUN_ID` instead -- then re-run with `-f commit=true`
 (`environment=dev` first, then `environment=prod`). For each `ready` row, it re-fetches the live
 `links` row and checks it still matches what was discovered during `gather`; if something changed
 in between (e.g. someone re-linked, or another operator already touched it), the row is marked

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -42,6 +42,13 @@ resource "azurerm_api_connection" "servicebus" {
   parameter_values = {
     connectionString = azurerm_servicebus_queue_authorization_rule.events_send.primary_connection_string
   }
+
+  # Azure never returns this secure value on refresh, so without ignore_changes every subsequent
+  # plan sees it as drifted and force-replaces the connection again. Already applied with the
+  # correct value on this environment -- safe to ignore from here on.
+  lifecycle {
+    ignore_changes = [parameter_values]
+  }
 }
 
 resource "azurerm_user_assigned_identity" "firehose" {

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -26,18 +26,18 @@ resource "azurerm_servicebus_queue_authorization_rule" "events_send" {
 
 data "azurerm_managed_api" "servicebus" {
   name     = "servicebus"
-  location = var.location
+  location = var.servicebus_managed_api_location
 }
 
 # Pre-existing Logic App connection (nihdevgithubportal's webhook-publishing workflow already
 # references $connections['servicebus']) -- must be `terraform import`ed before first apply, since
 # it already exists. Only the connection string changes here, to point at the queue above instead
-# of the old pre-migration namespace; the Logic App's own definition is untouched.
+# of the old pre-migration namespace; the Logic App's own definition is untouched. display_name is
+# intentionally omitted so the existing value ("events") is left as-is rather than renamed.
 resource "azurerm_api_connection" "servicebus" {
   name                = "servicebus"
   resource_group_name = var.resource_group_name
   managed_api_id      = data.azurerm_managed_api.servicebus.id
-  display_name        = "servicebus"
 
   parameter_values = {
     connectionString = azurerm_servicebus_queue_authorization_rule.events_send.primary_connection_string

--- a/infra/terraform/dev/main.tf
+++ b/infra/terraform/dev/main.tf
@@ -18,6 +18,32 @@ resource "azurerm_servicebus_queue" "events" {
   namespace_id = azurerm_servicebus_namespace.main.id
 }
 
+resource "azurerm_servicebus_queue_authorization_rule" "events_send" {
+  name     = "send-events"
+  queue_id = azurerm_servicebus_queue.events.id
+  send     = true
+}
+
+data "azurerm_managed_api" "servicebus" {
+  name     = "servicebus"
+  location = var.location
+}
+
+# Pre-existing Logic App connection (nihdevgithubportal's webhook-publishing workflow already
+# references $connections['servicebus']) -- must be `terraform import`ed before first apply, since
+# it already exists. Only the connection string changes here, to point at the queue above instead
+# of the old pre-migration namespace; the Logic App's own definition is untouched.
+resource "azurerm_api_connection" "servicebus" {
+  name                = "servicebus"
+  resource_group_name = var.resource_group_name
+  managed_api_id      = data.azurerm_managed_api.servicebus.id
+  display_name        = "servicebus"
+
+  parameter_values = {
+    connectionString = azurerm_servicebus_queue_authorization_rule.events_send.primary_connection_string
+  }
+}
+
 resource "azurerm_user_assigned_identity" "firehose" {
   name                = "nihdevgithubportal-firehose"
   resource_group_name = var.resource_group_name
@@ -28,4 +54,114 @@ resource "azurerm_role_assignment" "firehose_servicebus" {
   scope                = azurerm_servicebus_namespace.main.id
   role_definition_name = "Azure Service Bus Data Receiver"
   principal_id         = azurerm_user_assigned_identity.firehose.principal_id
+}
+
+# References to existing resources managed outside Terraform -- only their diagnostic settings
+# (below) are managed here, so nothing about the resources themselves is touched.
+data "azurerm_resources" "app_service" {
+  name                = var.app_service_name
+  resource_group_name = var.resource_group_name
+  type                = "Microsoft.Web/sites"
+}
+
+data "azurerm_postgresql_flexible_server" "main" {
+  name                = var.postgresql_flexible_server_name
+  resource_group_name = var.resource_group_name
+}
+
+data "azurerm_redis_cache" "main" {
+  name                = var.redis_name
+  resource_group_name = var.resource_group_name
+}
+
+data "azurerm_container_registry" "main" {
+  name                = var.container_registry_name
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_monitor_diagnostic_setting" "app_service" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_resources.app_service.resources[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "AppServiceHTTPLogs"
+  }
+  enabled_log {
+    category = "AppServiceConsoleLogs"
+  }
+  enabled_log {
+    category = "AppServiceAppLogs"
+  }
+  enabled_log {
+    category = "AppServicePlatformLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "postgresql" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_postgresql_flexible_server.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "PostgreSQLLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "redis" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_redis_cache.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "ConnectedClientList"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "container_registry" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_container_registry.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "ContainerRegistryRepositoryEvents"
+  }
+  enabled_log {
+    category = "ContainerRegistryLoginEvents"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "servicebus" {
+  name                       = "send-to-law"
+  target_resource_id         = azurerm_servicebus_namespace.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "OperationalLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
 }

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -26,3 +26,29 @@ variable "servicebus_namespace_name" {
   type        = string
   default     = "nihdevgithubportalsb"
 }
+
+# The following reference resources that already exist and are managed outside Terraform (App
+# Service, Postgres, Redis, ACR) -- only their diagnostic settings are managed here.
+variable "app_service_name" {
+  description = "Name of the existing App Service to wire up to Log Analytics"
+  type        = string
+  default     = "nihdevgithubportal"
+}
+
+variable "postgresql_flexible_server_name" {
+  description = "Name of the existing PostgreSQL Flexible Server to wire up to Log Analytics"
+  type        = string
+  default     = "nihdevgithubportaldb"
+}
+
+variable "redis_name" {
+  description = "Name of the existing Azure Cache for Redis instance to wire up to Log Analytics"
+  type        = string
+  default     = "nihdevgithubportal"
+}
+
+variable "container_registry_name" {
+  description = "Name of the existing Azure Container Registry to wire up to Log Analytics"
+  type        = string
+  default     = "nihdevgithubportal"
+}

--- a/infra/terraform/dev/variables.tf
+++ b/infra/terraform/dev/variables.tf
@@ -52,3 +52,12 @@ variable "container_registry_name" {
   type        = string
   default     = "nihdevgithubportal"
 }
+
+# The existing 'servicebus' Logic App connection was created in centralus, unlike the newer
+# resources above (var.location/eastus) -- managed_api_id is ForceNew, so this must match the
+# connection's actual region or Terraform will destroy and recreate it instead of updating in place.
+variable "servicebus_managed_api_location" {
+  description = "Region of the existing 'servicebus' managed API connection"
+  type        = string
+  default     = "centralus"
+}

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -26,18 +26,18 @@ resource "azurerm_servicebus_queue_authorization_rule" "events_send" {
 
 data "azurerm_managed_api" "servicebus" {
   name     = "servicebus"
-  location = var.location
+  location = var.servicebus_managed_api_location
 }
 
 # Pre-existing Logic App connection (nihgithubportalevents' webhook-publishing workflow already
 # references $connections['servicebus']) -- must be `terraform import`ed before first apply, since
 # it already exists. Only the connection string changes here, to point at the queue above instead
-# of the old pre-migration namespace; the Logic App's own definition is untouched.
+# of the old pre-migration namespace; the Logic App's own definition is untouched. display_name is
+# intentionally omitted so the existing value is left as-is rather than renamed.
 resource "azurerm_api_connection" "servicebus" {
   name                = "servicebus"
   resource_group_name = var.resource_group_name
   managed_api_id      = data.azurerm_managed_api.servicebus.id
-  display_name        = "servicebus"
 
   parameter_values = {
     connectionString = azurerm_servicebus_queue_authorization_rule.events_send.primary_connection_string

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -42,6 +42,13 @@ resource "azurerm_api_connection" "servicebus" {
   parameter_values = {
     connectionString = azurerm_servicebus_queue_authorization_rule.events_send.primary_connection_string
   }
+
+  # TODO: once this first apply has repointed the connection, add
+  #   lifecycle { ignore_changes = [parameter_values] }
+  # (as already done in infra/terraform/dev/main.tf) in a follow-up commit. Azure never returns
+  # this secure value on refresh, so every plan after that first apply will otherwise see it as
+  # drifted and force-replace the connection again. Not added yet: doing so before the initial
+  # apply would make Terraform ignore setting the new value at all, leaving prod not repointed.
 }
 
 resource "azurerm_user_assigned_identity" "firehose" {

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -18,6 +18,32 @@ resource "azurerm_servicebus_queue" "events" {
   namespace_id = azurerm_servicebus_namespace.main.id
 }
 
+resource "azurerm_servicebus_queue_authorization_rule" "events_send" {
+  name     = "send-events"
+  queue_id = azurerm_servicebus_queue.events.id
+  send     = true
+}
+
+data "azurerm_managed_api" "servicebus" {
+  name     = "servicebus"
+  location = var.location
+}
+
+# Pre-existing Logic App connection (nihgithubportalevents' webhook-publishing workflow already
+# references $connections['servicebus']) -- must be `terraform import`ed before first apply, since
+# it already exists. Only the connection string changes here, to point at the queue above instead
+# of the old pre-migration namespace; the Logic App's own definition is untouched.
+resource "azurerm_api_connection" "servicebus" {
+  name                = "servicebus"
+  resource_group_name = var.resource_group_name
+  managed_api_id      = data.azurerm_managed_api.servicebus.id
+  display_name        = "servicebus"
+
+  parameter_values = {
+    connectionString = azurerm_servicebus_queue_authorization_rule.events_send.primary_connection_string
+  }
+}
+
 resource "azurerm_user_assigned_identity" "firehose" {
   name                = "nihgithubportal-firehose"
   resource_group_name = var.resource_group_name
@@ -28,4 +54,114 @@ resource "azurerm_role_assignment" "firehose_servicebus" {
   scope                = azurerm_servicebus_namespace.main.id
   role_definition_name = "Azure Service Bus Data Receiver"
   principal_id         = azurerm_user_assigned_identity.firehose.principal_id
+}
+
+# References to existing resources managed outside Terraform -- only their diagnostic settings
+# (below) are managed here, so nothing about the resources themselves is touched.
+data "azurerm_resources" "app_service" {
+  name                = var.app_service_name
+  resource_group_name = var.resource_group_name
+  type                = "Microsoft.Web/sites"
+}
+
+data "azurerm_postgresql_flexible_server" "main" {
+  name                = var.postgresql_flexible_server_name
+  resource_group_name = var.resource_group_name
+}
+
+data "azurerm_redis_cache" "main" {
+  name                = var.redis_name
+  resource_group_name = var.resource_group_name
+}
+
+data "azurerm_container_registry" "main" {
+  name                = var.container_registry_name
+  resource_group_name = var.resource_group_name
+}
+
+resource "azurerm_monitor_diagnostic_setting" "app_service" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_resources.app_service.resources[0].id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "AppServiceHTTPLogs"
+  }
+  enabled_log {
+    category = "AppServiceConsoleLogs"
+  }
+  enabled_log {
+    category = "AppServiceAppLogs"
+  }
+  enabled_log {
+    category = "AppServicePlatformLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "postgresql" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_postgresql_flexible_server.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "PostgreSQLLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "redis" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_redis_cache.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "ConnectedClientList"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "container_registry" {
+  name                       = "send-to-law"
+  target_resource_id         = data.azurerm_container_registry.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "ContainerRegistryRepositoryEvents"
+  }
+  enabled_log {
+    category = "ContainerRegistryLoginEvents"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
+}
+
+resource "azurerm_monitor_diagnostic_setting" "servicebus" {
+  name                       = "send-to-law"
+  target_resource_id         = azurerm_servicebus_namespace.main.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log {
+    category = "OperationalLogs"
+  }
+
+  metric {
+    category = "AllMetrics"
+    enabled  = true
+  }
 }

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -26,3 +26,29 @@ variable "servicebus_namespace_name" {
   type        = string
   default     = "nihgithubportalsb"
 }
+
+# The following reference resources that already exist and are managed outside Terraform (App
+# Service, Postgres, Redis, ACR) -- only their diagnostic settings are managed here.
+variable "app_service_name" {
+  description = "Name of the existing App Service to wire up to Log Analytics"
+  type        = string
+  default     = "nihgithubportal"
+}
+
+variable "postgresql_flexible_server_name" {
+  description = "Name of the existing PostgreSQL Flexible Server to wire up to Log Analytics"
+  type        = string
+  default     = "nihgithubportaldb"
+}
+
+variable "redis_name" {
+  description = "Name of the existing Azure Cache for Redis instance to wire up to Log Analytics"
+  type        = string
+  default     = "nihgithubportal"
+}
+
+variable "container_registry_name" {
+  description = "Name of the existing Azure Container Registry to wire up to Log Analytics"
+  type        = string
+  default     = "nihgithubportal"
+}

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -52,3 +52,10 @@ variable "container_registry_name" {
   type        = string
   default     = "nihgithubportal"
 }
+
+# managed_api_id is ForceNew -- this must match the existing 'servicebus' connection's actual region.
+variable "servicebus_managed_api_location" {
+  description = "Region of the existing 'servicebus' managed API connection"
+  type        = string
+  default     = "eastus"
+}


### PR DESCRIPTION
## Summary

Merges infrastructure observability and webhook-pipeline fixes from `staging` into `main`: wires Log Analytics into every Azure resource that wasn't already covered, fixes a real bug where GitHub webhooks have been publishing into an orphaned pre-migration Service Bus queue since the June 2026 managed-identity cutover, redacts corporate-identity data from the public tenant-migration workflow's logs, and adds a `terraform import` action to both Terraform workflows. Dev has already been applied and verified; prod has been planned and imported (see below), with `apply` gated on this merge.

## Bug fixes

- **Webhook events silently stopped reaching firehose after the June 2026 Service Bus migration.** The `nihdevgithubportal`/`nihgithubportalevents` Logic App (the sole GitHub → Service Bus publishing path per `docs/webhooks.md`) was still wired to the old, pre-migration namespace's `events` queue via its `servicebus` API connection — firehose was moved to the new `nihdevgithubportalsb`/`nihgithubportalsb` namespace at the time, but the Logic App's connection was never repointed. Confirmed via matching `X-Ms-Workflow-Id`/`X-Ms-Workflow-Run-Id` response headers from a live GitHub webhook delivery against the Logic App's own run history. Result: dev's old queue accumulated 58 active + 1198 dead-lettered messages, prod's accumulated 620 active — `infra/terraform/{dev,prod}/main.tf` ([9ff5d34b](https://github.com/NIHGOV/github-portal/commit/9ff5d34b))
  - Adds a send-only `azurerm_servicebus_queue_authorization_rule` on the existing (Terraform-managed) `events` queue and imports the pre-existing `servicebus` API connection so its connection string can be repointed at the new namespace, without touching the Logic App's own definition.
  - Dev: imported, applied, and verified — `azurerm_api_connection.servicebus` now points at `nihdevgithubportalsb`.
  - Prod: imported and planned clean (`7 to add, 0 to change, 1 to destroy` — the expected connection-string replace); `apply` runs automatically on this merge.
- Fix `azurerm_api_connection.servicebus`'s `managed_api_id` forcing an unwanted resource replacement: the data source looked up the `servicebus` managed API in `var.location` (`eastus`), but dev's actual connection was created in `centralus` — added a dedicated `servicebus_managed_api_location` variable per environment so the region matches the existing resource instead of forcing a destroy/recreate — `infra/terraform/{dev,prod}/{main,variables}.tf` ([3bf07daa](https://github.com/NIHGOV/github-portal/commit/3bf07daa))

## Security / observability

- **Redact corporate-identity data from the public tenant-migration workflow log.** `applyMigration.ts`/`setTargets.ts` and the shared link-provider's column-change logging print full corporate GUIDs, emails, and display names to stdout; the workflow only redacted the gather-mode candidates-JSON block, leaving patch-mode runs fully exposed in this repo's world-readable Actions logs. Now scrubs GUIDs, emails, corporate-identity snapshot lines, and drift-comparison details from what's echoed into the job log (the container's own logs / Log Analytics are untouched) — `.github/workflows/tenant_migration.yml` ([9ff5d34b](https://github.com/NIHGOV/github-portal/commit/9ff5d34b))
- **Wire Log Analytics into every Azure resource that wasn't already covered.** Previously only the ACI containers (firehose, cache-builder, tenant-migration) sent diagnostics to LAW; the App Service, PostgreSQL Flexible Server, Redis Cache, Container Registry, and the Terraform-managed Service Bus namespace had none. Adds `azurerm_monitor_diagnostic_setting` for all five (referencing the existing resources via data sources — nothing about the resources themselves is imported/managed) in both dev and prod — `infra/terraform/{dev,prod}/main.tf` ([9ff5d34b](https://github.com/NIHGOV/github-portal/commit/9ff5d34b))
- Add a "this repo is public" note to `AGENTS.md` — code, commits, Actions logs, issues, and PRs are all world-readable; agents should flag anything that would leak credentials/PII/infra details before proceeding ([9ff5d34b](https://github.com/NIHGOV/github-portal/commit/9ff5d34b))

## CI / GitHub Actions

- Add an `import` action (plus `import_address`/`import_resource_id` inputs) to both `staging_terraform_dev.yml` and `main_terraform_prod.yml`, so `terraform import` can be run entirely through Actions (using the existing OIDC login) instead of requiring local/Cloud Shell access ([b25863e6](https://github.com/NIHGOV/github-portal/commit/b25863e6))
- Bump `hashicorp/setup-terraform` v3.1.2 → v4.0.1 (native Node 24, drops the Node 20 deprecation warning) ([13031123](https://github.com/NIHGOV/github-portal/commit/13031123))

## Docs / tooling

- `.cspell.json` — add `nihgithubportalevents`, `nihgithubportaldb` to the allowlist
