### PR TITLE
Fix deploy environment URL to point at public custom domain

### DIFF
--- a/.github/workflows/main_nihgithubportal.yml
+++ b/.github/workflows/main_nihgithubportal.yml
@@ -127,7 +127,9 @@ jobs:
       contents: read
     environment:
       name: 'Production'
-      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+      # azure/webapps-deploy's output is the raw *.azurewebsites.net hostname, not the custom
+      # domain (fronted by nihgithubportal-afd) that's actually public-facing.
+      url: 'https://portal.github.nih.gov'
 
     steps:
       - name: Download artifact from build job

--- a/.github/workflows/staging_nihdevgithubportal.yml
+++ b/.github/workflows/staging_nihdevgithubportal.yml
@@ -127,7 +127,9 @@ jobs:
       contents: read
     environment:
       name: 'Development'
-      url: ${{ steps.deploy-to-webapp.outputs.webapp-url }}
+      # azure/webapps-deploy's output is the raw *.azurewebsites.net hostname, not the custom
+      # domain (fronted by nihdevgithubportal-afd) that's actually public-facing.
+      url: 'https://dev.portal.github.nih.gov'
 
     steps:
       - name: Download artifact from build job


### PR DESCRIPTION
azure/webapps-deploy's `webapp-url` output is the raw `*.azurewebsites.net` hostname, not the custom domain (fronted by the Front Door instance) that's actually public-facing. Hardcodes the environment URL to `dev.portal.github.nih.gov` / `portal.github.nih.gov` instead so the PR's "View Deployment" button points somewhere real.