### PR TITLE
Add deferred ignore_changes for prod's servicebus connection

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -666,6 +666,7 @@
     "nihgithubportalevents",
     "repoint",
     "repointed",
+    "repointing",
     "nihgithubportalfh",
     "nihgithubportalsb",
     "noauth",

--- a/PLAN.md
+++ b/PLAN.md
@@ -64,6 +64,12 @@ Priority-ordered list of security improvements identified across this repository
   subject claim" under this repo's Settings → Actions → OIDC and updating the affected federated
   credentials to match; verified across all four distinct (app, subject) pairings used across the
   repo's workflows (dev/prod × ref-based/environment-based).
+- PR #1171 merged to `main` (2026-08-24): prod's push-triggered `Terraform Apply` ran for the
+  first time, repointing `azurerm_api_connection.servicebus` (destroy + recreate, same resource ID,
+  `Apply complete! Resources: 7 added, 0 changed, 1 destroyed.`) and the app deploy succeeded.
+  Added the deferred `lifecycle { ignore_changes = [parameter_values] }` to
+  `infra/terraform/prod/main.tf` now that the initial value is set, matching dev, so future plans
+  don't see the secure `connectionString` as drifted and force-replace the connection again.
 
 ---
 

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -43,12 +43,12 @@ resource "azurerm_api_connection" "servicebus" {
     connectionString = azurerm_servicebus_queue_authorization_rule.events_send.primary_connection_string
   }
 
-  # TODO: once this first apply has repointed the connection, add
-  #   lifecycle { ignore_changes = [parameter_values] }
-  # (as already done in infra/terraform/dev/main.tf) in a follow-up commit. Azure never returns
-  # this secure value on refresh, so every plan after that first apply will otherwise see it as
-  # drifted and force-replace the connection again. Not added yet: doing so before the initial
-  # apply would make Terraform ignore setting the new value at all, leaving prod not repointed.
+  # Azure never returns this secure value on refresh, so without ignore_changes every subsequent
+  # plan sees it as drifted and force-replaces the connection again. Already applied with the
+  # correct value on this environment -- safe to ignore from here on.
+  lifecycle {
+    ignore_changes = [parameter_values]
+  }
 }
 
 resource "azurerm_user_assigned_identity" "firehose" {


### PR DESCRIPTION
Follow-up to #1171: now that prod's first repoint apply has run (Apply complete! Resources: 7 added, 0 changed, 1 destroyed.), add the same `lifecycle { ignore_changes = [parameter_values] }` to `infra/terraform/prod/main.tf` that dev already has, so future plans don't see the secure `connectionString` as drifted and force-replace the connection again. No infra change (Terraform-only lifecycle metadata) -- next prod plan/apply should show no diff to this resource.